### PR TITLE
Added general logging settings.

### DIFF
--- a/gunnery/gunnery/settings/common.py
+++ b/gunnery/gunnery/settings/common.py
@@ -118,3 +118,45 @@ AUTH_USER_MODEL = 'account.CustomUser'
 ANONYMOUS_USER_ID = None
 
 PRIVATE_DIR = '/var/gunnery/secure'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+        },
+        'simple': {
+            'format': '%(asctime)s - %(levelname)s: %(message)s'
+        },
+    },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
+        },
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['mail_admins', 'console'],
+            'level': 'WARNING',
+            'propagate': True,
+        },
+        'gunnery': {
+            'handlers': ['mail_admins', 'console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}


### PR DESCRIPTION
Hi there, I added a basic logging configuration in the `common.py` settings. With this, you can actually have Python tracebacks on the console when developing the suite or in a file if you configure it for that when running in a server. Errors mailing to admins is also available. I missed this logging when trying Gunnery in my local.

You wrote a nice piece of software :) I think I'll give it a try in a couple of projects.

Hope you find this useful!
