### PR TITLE
Make ssh backend to actually use username

### DIFF
--- a/gunnery/backend/ssh.py
+++ b/gunnery/backend/ssh.py
@@ -41,7 +41,7 @@ class SSHTransport(Transport):
         client = SSHClient()
         client.set_missing_host_key_policy(AutoAddPolicy())
         client.load_host_keys(self.get_host_keys_file())
-        client.connect(self.server.host, pkey=private, look_for_keys=False, port=self.server.port)
+        client.connect(self.server.host, pkey=private, look_for_keys=False, port=self.server.port, username=self.server.user)
         return client
 
     def close_client(self):


### PR DESCRIPTION
otherwise you will get "Key authentication failed" as paramiko.SSHClient will use "gunnery" user.
