### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/puppetlabs/puppetlabs-stdlib.git
 [submodule "puppet/modules/python"]
 	path = puppet/modules/python
-	url = https://github.com/puppetmodules/puppet-module-python.git
+	url = https://github.com/Eyjafjallajokull/puppet-module-python
 [submodule "puppet/modules/postgresql"]
 	path = puppet/modules/postgresql
 	url = https://github.com/puppetlabs/puppetlabs-postgresql.git


### PR DESCRIPTION
original submodule repository 'https://github.com/puppetmodules/puppet-module-python.git/' deleted or made private by owner.
